### PR TITLE
Remove special handling of multiple inputs to pullbacks from ChainRules

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -22,7 +22,7 @@ ZygoteRules = "700de1a5-db45-46bc-99cf-38207098b444"
 [compat]
 AbstractFFTs = "0.5"
 ArrayLayouts = "0.1, 0.2"
-ChainRules = "0.5.1"
+ChainRules = "0.6.0"
 FillArrays = "0.8"
 ForwardDiff = "0"
 IRTools = "=0.3.1"

--- a/src/compiler/chainrules.jl
+++ b/src/compiler/chainrules.jl
@@ -49,12 +49,12 @@ Convert `x` from the differentials types ChainRules uses  to the format Zygote u
 @inline wrap_chainrules_output(x) = conj(unthunk(x))  # For now we are just not going to deal with thunks
 @inline wrap_chainrules_output(x::Tuple) = map(wrap_chainrules_output, x)
 @inline wrap_chainrules_output(x::ChainRules.AbstractZero) = nothing
-@inline function wrap_chainrules_output(x::ChainRules.Composite{P, T}) where {P, T}
-  T_outer = T <: NamedTuple  ? NamedTuple : Tuple  # must be a Tuple or NamedTuple, don't care about exact parameter types
-  xp = map(wrap_chainrules_output, x)
-  convert(T_outer, xp)
+for T_outer in (:Tuple, :NamedTuple)
+  @eval @inline function wrap_chainrules_output(x::ChainRules.Composite{P, T}) where {P, T<:$T_outer}
+    xp = map(wrap_chainrules_output, x)
+    convert($T_outer, xp)
+  end
 end
-
 
 """
     wrap_chainrules_input(x)
@@ -106,6 +106,3 @@ As per [`chain_rrule`](@ref) but with support for kwargs.
   kw_zpullback(dy) = (nothing, nothing, ZBack(back)(dy)...)  # first two nothings are for kwfunc and kwargs
   return y, kw_zpullback
 end
-
-# Required for nested AD
-@adjoint ChainRules.Composite{Any, T}(x::T) where T = ChainRules.Composite{Any, T}(x), x->(x,)

--- a/src/compiler/chainrules.jl
+++ b/src/compiler/chainrules.jl
@@ -50,8 +50,9 @@ Convert `x` from the differentials types ChainRules uses  to the format Zygote u
 @inline wrap_chainrules_output(x::Tuple) = map(wrap_chainrules_output, x)
 @inline wrap_chainrules_output(x::ChainRules.AbstractZero) = nothing
 for T_outer in (:Tuple, :NamedTuple)
-  # we create seperate methods rather than using a Union + a If so that we avoid a branch that changes output type
-    # because nested AD on that kinda thing make Zygote less than happy.
+  # we create separate methods rather than using a `Union` + an `if` so that we avoid a
+  # branch that changes output type, because nested AD on that kinda thing makes Zygote less
+  # than happy.
   @eval @inline function wrap_chainrules_output(x::ChainRules.Composite{P, T}) where {P, T<:$T_outer}
     xp = map(wrap_chainrules_output, x)
     convert($T_outer, xp)

--- a/src/compiler/chainrules.jl
+++ b/src/compiler/chainrules.jl
@@ -50,6 +50,8 @@ Convert `x` from the differentials types ChainRules uses  to the format Zygote u
 @inline wrap_chainrules_output(x::Tuple) = map(wrap_chainrules_output, x)
 @inline wrap_chainrules_output(x::ChainRules.AbstractZero) = nothing
 for T_outer in (:Tuple, :NamedTuple)
+  # we create seperate methods rather than using a Union + a If so that we avoid a branch that changes output type
+    # because nested AD on that kinda thing make Zygote less than happy.
   @eval @inline function wrap_chainrules_output(x::ChainRules.Composite{P, T}) where {P, T<:$T_outer}
     xp = map(wrap_chainrules_output, x)
     convert($T_outer, xp)

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -57,7 +57,7 @@ using Zygote, Test, ChainRules
         simo(x) = (5x, 7x)
         function ChainRules.rrule(::typeof(simo), x)
             simo_rrule_hitcount[] += 1
-            function simo_pullback(Δa, Δb)
+            function simo_pullback((Δa, Δb))
                 simo_pullback_hitcount[] += 1
                 return ChainRules.NO_FIELDS, 5*Δa + 7*Δb
             end
@@ -101,7 +101,7 @@ using Zygote, Test, ChainRules
         mimo(a, b) = (5a + 7b, 100a, 10b)
         function ChainRules.rrule(::typeof(mimo), a, b)
             mimo_rrule_hitcount[] += 1
-            function mimo_pullback(Δx, Δy, Δz)
+            function mimo_pullback((Δx, Δy, Δz))
                 mimo_pullback_hitcount[] += 1
                 return ChainRules.NO_FIELDS, 5Δx + 100Δy , 7Δx + 10Δz
             end
@@ -126,9 +126,7 @@ using Zygote, Test, ChainRules
 
     @testset "nested AD hitting identity(::Tuple) pullback" begin
         # This is is  a particularly fiddly case.
-        # the adjoint of `tuple` is `identity`
-        # and `identity(::Tuple)`s pullback has multiple inputs
-        # (since the primal had multiple outputs)
+        # Its kind of a simplified version of `sin'''(0.5)` but different in some places.
 
         f(x) = tuple(x, 2x, 3x)
 
@@ -177,8 +175,8 @@ using Zygote, Test, ChainRules
     end
 end
 
-# ChainRules doesn't have support for FastMath yet, so this fails
-# https://github.com/JuliaDiff/ChainRules.jl/issues/174
-@test_broken gradient(2.0) do x
-  @fastmath x^2.0
-end == (4.0,)
+@testset "FastMath support" begin
+    @test gradient(2.0) do x
+      @fastmath x^2.0
+    end == (4.0,)
+end


### PR DESCRIPTION
This is a PR against #366 
However, it needs a bunch of other stuff to be tagged first.
So it should not be treated as blocking #366 as that might be a while.
I have tested it locally,
it does give a bit of a performance boost.
(Not huge but a bit)

Mostly it makes the code cleaner.